### PR TITLE
Fix role assignment input validation

### DIFF
--- a/easymq.sh
+++ b/easymq.sh
@@ -201,6 +201,11 @@ manage_roles() {
             done
 
             read -p "Enter the number of the user: " user_number
+            if [[ -z "$user_number" || $user_number -lt 1 || $user_number -gt ${#user_array[@]} ]]; then
+                echo "Invalid selection. Operation cancelled."
+                return
+            fi
+
             selected_user=${user_array[$((user_number-1))]}
             echo "User '$selected_user' currently has the following roles:"
             $MOSQUITTO_CTRL_CMD getClient "$selected_user"
@@ -213,6 +218,11 @@ manage_roles() {
             done
 
             read -p "Enter the number of the role: " role_number
+            if [[ -z "$role_number" || $role_number -lt 1 || $role_number -gt ${#role_array[@]} ]]; then
+                echo "Invalid selection. Operation cancelled."
+                return
+            fi
+
             selected_role=${role_array[$((role_number-1))]}
             $MOSQUITTO_CTRL_CMD addClientRole "$selected_user" "$selected_role"
             echo "Role '$selected_role' assigned to user '$selected_user'."


### PR DESCRIPTION
## Summary
- guard against invalid user or role selection when assigning roles in `manage_roles`

## Testing
- `bash -n easymq.sh`
- `apt-get update -y` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6883f4e91078832f9f0950a1e6ea3fce